### PR TITLE
Modify to correct word Lombock to Lombok library

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ However there are some rector needs at this time.
 Preliminary we have to focus on following refactor and changes:
 
 * Change AngularJS style to Papa Style
-* Apply Lombock library on Java side
+* Apply Lombok library on Java side
 * Migrate to Liquibase
 
 In relation to issues, there will be worth to talk about them once refactor and several features described in the section below will be done.


### PR DESCRIPTION
For annotation based POJO class we used https://projectlombok.org/ Lombok library.
So we need to correct Lombock  word to Lombok.