### PR TITLE
Add an unit test for changeUserAvatar method of UserServiceImpl. Resolved #199

### DIFF
--- a/abixen-platform-core/src/test/java/com/abixen/platform/core/configuration/properties/PlatformTestResourceConfigurationProperties.java
+++ b/abixen-platform-core/src/test/java/com/abixen/platform/core/configuration/properties/PlatformTestResourceConfigurationProperties.java
@@ -25,7 +25,7 @@ public class PlatformTestResourceConfigurationProperties extends AbstractPlatfor
 
     @PostConstruct
     public void init() {
-        setImageLibraryDirectory("${baseDir}/../data/image-library/");
+        setImageLibraryDirectory("${baseDir}/data/image-library/");
     }
 
 }


### PR DESCRIPTION
I modify setImageLibraryDirectory path for test,

changeUserAvatar method has incorrect condition for exception
if (currentAvatarFile.exists()) {
            if (!currentAvatarFile.delete()) {
                throw new FileExistsException();
            }
        }

Because if file present on filesystem, than file.delete() always return true -> exception newer throwed