### PR TITLE
236-Migrate logger to log4j 2 for the web client microservice

### DIFF
--- a/abixen-platform-web-client/pom.xml
+++ b/abixen-platform-web-client/pom.xml
@@ -24,6 +24,8 @@
         <start-class>com.abixen.platform.client.web.PlatformWebClientApplication</start-class>
         <docker.plugin.version>0.4.13</docker.plugin.version>
         <docker.image.prefix>abixen-platform</docker.image.prefix>
+        <log4j2.version>2.5</log4j2.version>
+        <log4j-slf4j-version>2.0.1</log4j-slf4j-version>
     </properties>
 
 
@@ -127,6 +129,24 @@
             <groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
             <scope>provided</scope>
+        </dependency>
+
+        <!-- Logger -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j2.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j-slf4j-version}</version>
         </dependency>
 
     </dependencies>

--- a/abixen-platform-web-client/src/main/resources/log4j.properties
+++ b/abixen-platform-web-client/src/main/resources/log4j.properties
@@ -1,5 +1,0 @@
-log4j.rootLogger=INFO, CA
-log4j.logger.com.abixen=DEBUG
-log4j.appender.CA=org.apache.log4j.ConsoleAppender
-log4j.appender.CA.layout=org.apache.log4j.PatternLayout
-log4j.appender.CA.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss SSS} [%p] [c=%c{1}] %m%n

--- a/abixen-platform-web-client/src/main/resources/log4j2.xml
+++ b/abixen-platform-web-client/src/main/resources/log4j2.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="info" name="XMLConfigTest" packages="org.apache.logging.log4j.test">
+    <Properties>
+        <Property name="pattern">%d{yyyy-MM-dd HH:mm:ss SSS} [%p] [c=%c{1}] %m%n</Property>
+        <Property name="logsPath">logs</Property>
+    </Properties>
+
+    <Appenders>
+        <Console name="STDOUT">
+            <PatternLayout>
+                <pattern>${pattern}</pattern>
+            </PatternLayout>
+        </Console>
+        <RollingFile name="webClientAppLog" fileName="${logsPath}/abixen-platform-web-client-app.log"
+                     filePattern="${logsPath}/$${date:yyyy-MM}/abixen-platform-web-client-app-%d{MM-dd-yyyy}-%i.log.gz">
+            <PatternLayout>
+            <pattern>${pattern}</pattern>
+        </PatternLayout>
+            <policies>
+                <SizeBasedTriggeringPolicy size="10 MB" />
+            </policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+
+        <RollingFile name="webClientRootLog" fileName="${logsPath}/abixen-platform-web-client-root.log"
+                     filePattern="${logsPath}/$${date:yyyy-MM}/abixen-platform-web-client-root-%d{MM-dd-yyyy}-%i.log.gz">
+            <PatternLayout>
+                <pattern>${pattern}</pattern>
+            </PatternLayout>
+            <policies>
+                <SizeBasedTriggeringPolicy size="1 KB" />
+            </policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+</Appenders>
+    <Loggers>
+        <Logger name="com.abixen.platform.client.web" level="debug" additivity="false">
+            <AppenderRef ref="STDOUT"/>
+            <AppenderRef ref="webClientAppLog">
+            </AppenderRef>
+        </Logger>
+
+        <Logger name="org.springframework" level="info" additivity="false">
+            <AppenderRef ref="webClientAppLog">
+            </AppenderRef>
+            <AppenderRef ref="STDOUT" level="warn"/>
+        </Logger>
+
+        <Root level="info">
+            <AppenderRef ref="STDOUT"/>
+            <AppenderRef ref="webClientRootLog">
+            </AppenderRef>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
Please review the changes.
Added log4j2.xml and respective dependencies.
No changes in the java code. because it already  using slf4j classes. 