### PR TITLE
Added Xmx limit in docker-compose and adjusted Dockerfiles.

### DIFF
--- a/abixen-platform-business-intelligence-service/src/main/docker/Dockerfile
+++ b/abixen-platform-business-intelligence-service/src/main/docker/Dockerfile
@@ -2,4 +2,5 @@ FROM openjdk:8-jre
 VOLUME /tmp
 ADD abixen-platform-business-intelligence-service.jar app.jar
 RUN bash -c 'touch /app.jar'
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dspring.profiles.active=cloud","-Dabixen.services.eureka.uri=discovery","-jar","/app.jar"]
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dspring.profiles.active=cloud","-Dabixen.services.eureka.uri=discovery"]
+CMD ["-jar","/app.jar"]

--- a/abixen-platform-configuration/src/main/docker/Dockerfile
+++ b/abixen-platform-configuration/src/main/docker/Dockerfile
@@ -4,4 +4,5 @@ VOLUME /tmp
 ADD abixen-platform-configuration.jar app.jar
 RUN bash -c 'touch /app.jar'
 EXPOSE 8888
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dabixen.services.eureka.uri=discovery","-jar","/app.jar"]
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dabixen.services.eureka.uri=discovery"]
+CMD ["-jar","/app.jar"]

--- a/abixen-platform-core/src/main/docker/Dockerfile
+++ b/abixen-platform-core/src/main/docker/Dockerfile
@@ -2,4 +2,5 @@ FROM openjdk:8-jre
 VOLUME /tmp
 ADD abixen-platform-core.jar app.jar
 RUN bash -c 'touch /app.jar'
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dspring.profiles.active=cloud","-Dabixen.services.eureka.uri=discovery","-jar","/app.jar"]
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dspring.profiles.active=cloud","-Dabixen.services.eureka.uri=discovery"]
+CMD ["-jar","/app.jar"]

--- a/abixen-platform-eureka/src/main/docker/Dockerfile
+++ b/abixen-platform-eureka/src/main/docker/Dockerfile
@@ -3,4 +3,5 @@ VOLUME /tmp
 ADD abixen-platform-eureka.jar app.jar
 RUN bash -c 'touch /app.jar'
 EXPOSE 8761
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dabixen.services.eureka.uri=discovery","-jar","/app.jar"]
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dabixen.services.eureka.uri=discovery"]
+CMD ["-jar","/app.jar"]

--- a/abixen-platform-gateway/src/main/docker/Dockerfile
+++ b/abixen-platform-gateway/src/main/docker/Dockerfile
@@ -3,4 +3,5 @@ VOLUME /tmp
 ADD abixen-platform-gateway.jar app.jar
 RUN bash -c 'touch /app.jar'
 EXPOSE 9090
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dspring.profiles.active=cloud","-Dabixen.services.eureka.uri=discovery","-jar","/app.jar"]
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dspring.profiles.active=cloud","-Dabixen.services.eureka.uri=discovery"]
+CMD ["-jar","/app.jar"]

--- a/abixen-platform-hystrix-dashboard/src/main/docker/Dockerfile
+++ b/abixen-platform-hystrix-dashboard/src/main/docker/Dockerfile
@@ -3,4 +3,5 @@ VOLUME /tmp
 ADD abixen-platform-hystrix-dashboard.jar app.jar
 RUN bash -c 'touch /app.jar'
 EXPOSE 8989
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dspring.profiles.active=cloud","-Dabixen.services.eureka.uri=discovery","-jar","/app.jar"]
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dspring.profiles.active=cloud","-Dabixen.services.eureka.uri=discovery"]
+CMD ["-jar","/app.jar"]

--- a/abixen-platform-web-client/src/main/docker/Dockerfile
+++ b/abixen-platform-web-client/src/main/docker/Dockerfile
@@ -3,4 +3,5 @@ VOLUME /tmp
 ADD abixen-platform.war app.war
 RUN bash -c 'touch /app.war'
 EXPOSE 8080
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dspring.profiles.active=cloud","-Dabixen.services.eureka.uri=discovery","-Dabixen.services.gateway.uri=gateway","-jar","/app.war"]
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dspring.profiles.active=cloud","-Dabixen.services.eureka.uri=discovery","-Dabixen.services.gateway.uri=gateway"]
+CMD ["-jar","/app.war"]

--- a/abixen-platform-web-content-service/src/main/docker/Dockerfile
+++ b/abixen-platform-web-content-service/src/main/docker/Dockerfile
@@ -2,4 +2,5 @@ FROM openjdk:8-jre
 VOLUME /tmp
 ADD abixen-platform-web-content-service.jar app.jar
 RUN bash -c 'touch /app.jar'
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dspring.profiles.active=cloud","-Dabixen.services.eureka.uri=discovery","-jar","/app.jar"]
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dspring.profiles.active=cloud","-Dabixen.services.eureka.uri=discovery"]
+CMD ["-jar","/app.jar"]

--- a/abixen-platform-zipkin/src/main/docker/Dockerfile
+++ b/abixen-platform-zipkin/src/main/docker/Dockerfile
@@ -4,4 +4,5 @@ VOLUME /tmp
 ADD abixen-platform-zipkin.jar app.jar
 RUN bash -c 'touch /app.jar'
 EXPOSE 8888
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dspring.profiles.active=platform-cloud","-Dabixen.services.eureka.uri=discovery","-jar","/app.jar"]
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dspring.profiles.active=platform-cloud","-Dabixen.services.eureka.uri=discovery"]
+CMD ["-jar","/app.jar"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,6 +26,7 @@ services:
 
   discovery:
     image: abixen-platform/abixen-platform-eureka
+    command: -Xmx512m -jar /app.jar
     ports:
       - "8761:8761"
     extends:
@@ -33,6 +34,7 @@ services:
 
   configuration:
     image: abixen-platform/abixen-platform-configuration
+    command: -Xmx512m -jar /app.jar
     depends_on:
       - discovery
     extends:
@@ -40,7 +42,7 @@ services:
 
   gateway:
     image: abixen-platform/abixen-platform-gateway
-    command: -Xmx=512m
+    command: -Xmx512m -jar /app.jar
     depends_on:
       - discovery
       - configuration
@@ -54,6 +56,7 @@ services:
 
   business-intelligence-service:
     image: abixen-platform/abixen-platform-business-intelligence-service
+    command: -Xmx512m -jar /app.jar
     depends_on:
       - discovery
       - configuration
@@ -65,6 +68,7 @@ services:
 
   web-content-service:
     image: abixen-platform/abixen-platform-web-content-service
+    command: -Xmx1024m -jar /app.jar
     depends_on:
       - discovery
       - configuration
@@ -76,6 +80,7 @@ services:
 
   core:
     image: abixen-platform/abixen-platform-core
+    command: -Xmx1024m -jar /app.jar
     depends_on:
       - discovery
       - configuration
@@ -90,6 +95,7 @@ services:
 
   web-client:
     image: abixen-platform/abixen-platform-web-client
+    command: -Xmx512m -jar /app.war
     depends_on:
      - discovery
      - configuration
@@ -100,11 +106,10 @@ services:
       - "traefik.port=8080"
       - "traefik.frontend.rule=Host:platform.abixen.devd.io"
       - "traefik.backend.loadbalancer.sticky=true"
-    extends:
-      service: base
 
   hystrix-dashboard:
     image: abixen-platform/abixen-platform-hystrix-dashboard
+    command: -Xmx512m -jar /app.jar
     ports:
       - "8989:8989"
     depends_on:
@@ -117,6 +122,7 @@ services:
 
   zipkin:
     image: abixen-platform/abixen-platform-zipkin
+    command: -Xmx512m -jar /app.jar
     ports:
       - "9411:9411"
     depends_on:
@@ -200,12 +206,10 @@ services:
 
   logstash:
     image: logstash:5-alpine
-    #command: logstash -f /etc/logstash/conf.d/logstash.conf
-    #command: logstash -e 'input { gelf { } } filter { } output { elasticsearch { hosts => "elasticsearch:9200" } }'
-    command: logstash -e 'input { gelf { } } filter { } output { elasticsearch { hosts => "elasticsearch:9200" } stdout { codec => rubydebug } }'
+    command: logstash -e 'input { gelf { } } filter { } output { elasticsearch { hosts => "elasticsearch:9200" } }'
+    # uncomment to enable output of all incoming messages to stdout of logstash container
+    # command: logstash -e 'input { gelf { } } filter { } output { elasticsearch { hosts => "elasticsearch:9200" } stdout { codec => rubydebug } }'
 
-#    volumes:
-#      - ./logstash/:/etc/logstash/conf.d
     ports:
       - "12201:12201/udp"
     depends_on:

--- a/zipkin-web/Dockerfile
+++ b/zipkin-web/Dockerfile
@@ -3,4 +3,6 @@ FROM openjdk:8-jre
 EXPOSE 9412
 COPY lib/ /zipkin-web/
 
-CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "-jar","/zipkin-web/zipkin-web-all.jar", "-zipkin.web.port=:9412", "-zipkin.web.rootUrl=/", "-zipkin.web.query.dest=zipkin:9411"]
+ENTRYPOINT ["java", "-Djava.security.egd=file:/dev/./urandom"]
+CMD ["-jar","/zipkin-web/zipkin-web-all.jar", "-zipkin.web.port=:9412", "-zipkin.web.rootUrl=/", "-zipkin.web.query.dest=zipkin:9411"]
+


### PR DESCRIPTION
Resolved #633.

Dockerfiles needed modification since Xmx settings need to be defined before -jar option. It will enable more flexibility since adding custom options to JVM won't require docker image rebuilding.