### PR TITLE
Removed touch command in Dockerfiles to minimize image size

### DIFF
--- a/abixen-platform-business-intelligence-service/src/main/docker/Dockerfile
+++ b/abixen-platform-business-intelligence-service/src/main/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-jre
 VOLUME /tmp
 ADD abixen-platform-business-intelligence-service.jar app.jar
-RUN bash -c 'touch /app.jar'
+
 ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dspring.profiles.active=docker","-Dabixen.services.eureka.uri=discovery"]
 CMD ["-jar","/app.jar"]

--- a/abixen-platform-configuration/src/main/docker/Dockerfile
+++ b/abixen-platform-configuration/src/main/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8-jre
 VOLUME /tmp
 VOLUME /tmp
 ADD abixen-platform-configuration.jar app.jar
-RUN bash -c 'touch /app.jar'
+
 EXPOSE 8888
 ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dabixen.services.eureka.uri=discovery"]
 CMD ["-jar","/app.jar"]

--- a/abixen-platform-core/src/main/docker/Dockerfile
+++ b/abixen-platform-core/src/main/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-jre
 VOLUME /tmp
 ADD abixen-platform-core.jar app.jar
-RUN bash -c 'touch /app.jar'
+
 ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dspring.profiles.active=docker","-Dabixen.services.eureka.uri=discovery"]
 CMD ["-jar","/app.jar"]

--- a/abixen-platform-eureka/src/main/docker/Dockerfile
+++ b/abixen-platform-eureka/src/main/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:8-jre
 VOLUME /tmp
 ADD abixen-platform-eureka.jar app.jar
-RUN bash -c 'touch /app.jar'
+
 EXPOSE 8761
 ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dabixen.services.eureka.uri=discovery"]
 CMD ["-jar","/app.jar"]

--- a/abixen-platform-gateway/src/main/docker/Dockerfile
+++ b/abixen-platform-gateway/src/main/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:8-jre
 VOLUME /tmp
 ADD abixen-platform-gateway.jar app.jar
-RUN bash -c 'touch /app.jar'
+
 EXPOSE 9090
 ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dspring.profiles.active=docker","-Dabixen.services.eureka.uri=discovery"]
 CMD ["-jar","/app.jar"]

--- a/abixen-platform-hystrix-dashboard/src/main/docker/Dockerfile
+++ b/abixen-platform-hystrix-dashboard/src/main/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:8-jre
 VOLUME /tmp
 ADD abixen-platform-hystrix-dashboard.jar app.jar
-RUN bash -c 'touch /app.jar'
+
 EXPOSE 8989
 ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dspring.profiles.active=docker","-Dabixen.services.eureka.uri=discovery"]
 CMD ["-jar","/app.jar"]

--- a/abixen-platform-web-content-service/src/main/docker/Dockerfile
+++ b/abixen-platform-web-content-service/src/main/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-jre
 VOLUME /tmp
 ADD abixen-platform-web-content-service.jar app.jar
-RUN bash -c 'touch /app.jar'
+
 ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dspring.profiles.active=docker","-Dabixen.services.eureka.uri=discovery"]
 CMD ["-jar","/app.jar"]

--- a/abixen-platform-zipkin/src/main/docker/Dockerfile
+++ b/abixen-platform-zipkin/src/main/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8-jre
 VOLUME /tmp
 VOLUME /tmp
 ADD abixen-platform-zipkin.jar app.jar
-RUN bash -c 'touch /app.jar'
+
 EXPOSE 8888
 ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Dspring.profiles.active=docker","-Dabixen.services.eureka.uri=discovery"]
 CMD ["-jar","/app.jar"]


### PR DESCRIPTION
I know it was taken from https://spring.io/guides/gs/spring-boot-docker/ , but I don't think it's necessary since it also doubles size of all images which makes them unusable.