### PR TITLE
Fixed failed builds when docker config file is not available

### DIFF
--- a/abixen-platform-business-intelligence-service/pom.xml
+++ b/abixen-platform-business-intelligence-service/pom.xml
@@ -304,7 +304,7 @@
                         <imageTag>${project.version}</imageTag>
                         <imageTag>latest</imageTag>
                     </imageTags>
-                    <useConfigFile>true</useConfigFile>
+                    <useConfigFile>false</useConfigFile>
                     <resources>
                         <resource>
                             <targetPath>/</targetPath>

--- a/abixen-platform-configuration/pom.xml
+++ b/abixen-platform-configuration/pom.xml
@@ -89,7 +89,7 @@
                         <imageTag>${project.version}</imageTag>
                         <imageTag>latest</imageTag>
                     </imageTags>
-                    <useConfigFile>true</useConfigFile>
+                    <useConfigFile>false</useConfigFile>
                     <resources>
                         <resource>
                             <targetPath>/</targetPath>

--- a/abixen-platform-core/pom.xml
+++ b/abixen-platform-core/pom.xml
@@ -278,7 +278,7 @@
                         <imageTag>${project.version}</imageTag>
                         <imageTag>latest</imageTag>
                     </imageTags>
-                    <useConfigFile>true</useConfigFile>
+                    <useConfigFile>false</useConfigFile>
                     <resources>
                         <resource>
                             <targetPath>/</targetPath>

--- a/abixen-platform-eureka/pom.xml
+++ b/abixen-platform-eureka/pom.xml
@@ -80,7 +80,7 @@
                         <imageTag>${project.version}</imageTag>
                         <imageTag>latest</imageTag>
                     </imageTags>
-                    <useConfigFile>true</useConfigFile>
+                    <useConfigFile>false</useConfigFile>
                     <resources>
                         <resource>
                             <targetPath>/</targetPath>

--- a/abixen-platform-gateway/pom.xml
+++ b/abixen-platform-gateway/pom.xml
@@ -182,7 +182,7 @@
                         <imageTag>${project.version}</imageTag>
                         <imageTag>latest</imageTag>
                     </imageTags>
-                    <useConfigFile>true</useConfigFile>
+                    <useConfigFile>false</useConfigFile>
                     <resources>
                         <resource>
                             <targetPath>/</targetPath>

--- a/abixen-platform-hystrix-dashboard/pom.xml
+++ b/abixen-platform-hystrix-dashboard/pom.xml
@@ -107,7 +107,7 @@
                         <imageTag>${project.version}</imageTag>
                         <imageTag>latest</imageTag>
                     </imageTags>
-                    <useConfigFile>true</useConfigFile>
+                    <useConfigFile>false</useConfigFile>
                     <resources>
                         <resource>
                             <targetPath>/</targetPath>

--- a/abixen-platform-web-client/pom.xml
+++ b/abixen-platform-web-client/pom.xml
@@ -231,7 +231,7 @@
                         <imageTag>${project.version}</imageTag>
                         <imageTag>latest</imageTag>
                     </imageTags>
-                    <useConfigFile>true</useConfigFile>
+                    <useConfigFile>false</useConfigFile>
                     <resources>
                         <resource>
                             <targetPath>/</targetPath>

--- a/abixen-platform-web-content-service/pom.xml
+++ b/abixen-platform-web-content-service/pom.xml
@@ -266,7 +266,7 @@
                         <imageTag>${project.version}</imageTag>
                         <imageTag>latest</imageTag>
                     </imageTags>
-                    <useConfigFile>true</useConfigFile>
+                    <useConfigFile>false</useConfigFile>
                     <resources>
                         <resource>
                             <targetPath>/</targetPath>

--- a/abixen-platform-zipkin/pom.xml
+++ b/abixen-platform-zipkin/pom.xml
@@ -95,7 +95,7 @@
                         <imageTag>${project.version}</imageTag>
                         <imageTag>latest</imageTag>
                     </imageTags>
-                    <useConfigFile>true</useConfigFile>
+                    <useConfigFile>false</useConfigFile>
                     <resources>
                         <resource>
                             <targetPath>/</targetPath>


### PR DESCRIPTION
We have to come up with some other way of pushing images. Probably build profiles available in the spotify plugin.