### PR TITLE
Addition of CNCF Cloud Native deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,30 +76,18 @@ Abixen Platform is fully compatible with AWS cloud and utilizes the following se
    ![Abixen Platform AWS Deployment diagram](documentation-image/abixen-platform-on-aws.png "Abixen Platform AWS Deployment diagram")
    
 ## CNCF Cloud Native Landscape compatible
-Abixen Platform can be containerized to become fully compatible with CNCF Cloud Native Landscape and it's catogories and sub-catogories of cloud native components. The platform can execute based on the following OSS components and CNCF projects (both OSS and open standards): (this list is initially focused only on the **Infrastructure, Runtime, Orchestration & Management, Platforms and Observability and Analysis categories** of the CNCF Cloud Native Landscape)
+Abixen Platform can be containerized to become fully compatible with CNCF Cloud Native Landscape and its categories and sub-categories of cloud native components. The platform can execute based on the following OSS components and CNCF projects (both OSS and open standards): (this list is initially focused only on the Infrastructure, Runtime, Orchestration & Management, Platforms and Observability and Analysis categories of the CNCF Cloud Native Landscape)
 
-- **Infrastructure catogory:**
-	Cloud - Public or Private, Hybrid or Bare Metal (i.e Canonical MaaS or OpenSatck on Bare Metal or any public cloud provider)
+•	Infrastructure category: Cloud - Public or Private, Hybrid or Bare Metal (i.e. Canonical MaaS or OpenStack on Bare Metal or any public cloud provider)
 
-- **Runtime catorgory:**
-	**Cloud Native Network sub-catogory** based on the open standard CNI
-	**Container Runtime sub-catogory** including OSS Containerd (docker), rkt and open standard CRI-O
-	**Cloud Native storage sub-catogory** including OSS Rook and/or traditional Swift-based storage options and open standard CSI
+•	Runtime category: Cloud Native Network sub-category based on the open standard CNI Container Runtime sub-category including OSS Containerd (docker), rkt and open standard CRI-O Cloud Native storage sub-category including OSS Rook and/or traditional Swift-based storage options and open standard CSI
 
-- **Orchestration & Management catorgory:**
-	**Scheduling & Orchestration sub-catogory** including OSS Kubernetes and Hashicorp Nomad
-	**Cooridantion & Service Discovery sub-catogory** including OSS CoreDNS, etcd and/or Hashicorp Consul
-	**Service Management sub-catogory** including OSS envoy, linkerd, gRPC and/or and/or Ambassador and open standard OPA 
+•	Orchestration & Management category: Scheduling & Orchestration sub-category including OSS Kubernetes and Hashicorp Nomad Coordination & Service Discovery sub-category including OSS CoreDNS, etcd and/or Hashicorp Consul Service Management sub-category including OSS envoy, linkerd, gRPC and/or Ambassador and open standard OPA
 
-- **Platforms catorgory:**
-	**PaaS/Container Service sub-catogory** including OSS Jhipster (for java objects) and/or OSS Kontena
-	**Certified Kubernetes - Distribyution sub-catogory** including OSS Rancher and/or OSS Canonical Distribution of Kubernetes
-	**Certified Kubernetes - Hosted sub-catogory** inclduing public cloud services AWS EKS, Azure ACS and/or Google Kubernetes Engine
-	
-- **Observability and Analysis catorgory:**
-	**Monitoring sub-catogory** inclduing OSS Prometheus, Grafana, InfluxDB, heapster
-	**Logging sub-catogory** inclduing OSS fluentd, Elastic
-	**Tracing sub-catogory** inclduing OSS OpenTracing, Jaeger, Zipkin
+•	Platforms category: PaaS/Container Service sub-category including OSS Jhipster (for java objects) and/or OSS Kontena Certified Kubernetes - Distribution sub-category including OSS Rancher and/or OSS Canonical Distribution of Kubernetes Certified Kubernetes - Hosted sub-category including public cloud services AWS EKS, Azure ACS and/or Google Kubernetes Engine
+
+•	Observability and Analysis category: Monitoring sub-category including OSS Prometheus, Grafana, InfluxDB, heapster Logging sub-category including OSS fluentd, Elastic Tracing sub-category including OSS OpenTracing, Jaeger, Zipkin
+
      
 ![CNCF Cloud Native Landscape Diagram](https://github.com/cncf/landscape/raw/master/landscape/CloudNativeLandscape_latest.png "CNCF Cloud Native Landscape Diagram")
 For more details on the CNCF Cloud Native Landscape, go here - https://landscape.cncf.io/

--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ Abixen Platform can be containiized is fully compatible with the CNCF Cloud Nati
    * **RDS** - database store for all components
    * **SES** - used for email communication
    
-https://github.com/cncf/landscape/raw/master/landscape/CloudNativeLandscape_latest.png
-For mre details on the 
+![CNCF Cloud Native Landscape Diagram](https://github.com/cncf/landscape/raw/master/landscape/CloudNativeLandscape_latest.png "CNCF Cloud Native Landscape Diagram")
+For more details on the CNCF Cloud Native Landscape, go here - https://landscape.cncf.io/
+
 ## Logging and monitoring
 All containers from Abixen Platform send logs to [Elasticsearch](https://www.elastic.co) via [Logstash](https://www.elastic.co/products/logstash). You can use [Kibana's](https://www.elastic.co/products/kibana) interface as well.
 All metrics are exposed on each component with [Jolokia](http://jolokia.org) and fetched from there using [Telegraf](https://influxdata.com/telegraf-correlate-log-metrics-data-performance-bottlenecks/). They are sent to [InfluxDB](https://influxdata.com/) and are accessible on [Grafana](https://grafana.net) dashboards

--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ The Abixen Platform can also be containerized to become fully compatible with CN
 •	**Platforms category:** **PaaS/Container Service sub-category** including OSS Jhipster (for java objects) and/or OSS Kontena **ertified Kubernetes - Distribution sub-category** including OSS Rancher and/or OSS Canonical Distribution of Kubernetes **Certified Kubernetes - Hosted sub-category** including public cloud services AWS EKS, Azure ACS and/or Google Kubernetes Engine
 
 •	**Observability and Analysis category:** **Monitoring sub-category** including OSS Prometheus, Grafana, InfluxDB, heapster **ogging sub-category** including OSS fluentd, Elastic **racing sub-category** including OSS OpenTracing, Jaeger, Zipkin
-
      
 ![CNCF Cloud Native Landscape Diagram](https://github.com/cncf/landscape/raw/master/landscape/CloudNativeLandscape_latest.png "CNCF Cloud Native Landscape Diagram")
 For more details on the CNCF Cloud Native Landscape, go here - https://landscape.cncf.io/

--- a/README.md
+++ b/README.md
@@ -78,19 +78,19 @@ Abixen Platform is fully compatible with AWS cloud and utilizes the following se
 ## CNCF Cloud Native Landscape compatible
 Abixen Platform can be containerized to become fully compatible with CNCF Cloud Native Landscape and its categories and sub-categories of cloud native components. The platform can execute based on the following OSS components and CNCF projects (both OSS and open standards): (this list is initially focused only on the Infrastructure, Runtime, Orchestration & Management, Platforms and Observability and Analysis categories of the CNCF Cloud Native Landscape)
 
-•	Infrastructure category: Cloud - Public or Private, Hybrid or Bare Metal (i.e. Canonical MaaS or OpenStack on Bare Metal or any public cloud provider)
+•	**Infrastructure category:** Cloud - Public or Private, Hybrid or Bare Metal (i.e. Canonical MaaS or OpenStack on Bare Metal or any public cloud provider)
 
-•	Runtime category: Cloud Native Network sub-category based on the open standard CNI Container Runtime sub-category including OSS Containerd (docker), rkt and open standard CRI-O Cloud Native storage sub-category including OSS Rook and/or traditional Swift-based storage options and open standard CSI
+•	**Runtime category:** **Cloud Native Network sub-category** based on the open standard CNI **Container Runtime sub-category** including OSS Containerd (docker), rkt and open standard CRI-O **Cloud Native storage sub-category** including OSS Rook and/or traditional Swift-based storage options and open standard CSI
 
-•	Orchestration & Management category: Scheduling & Orchestration sub-category including OSS Kubernetes and Hashicorp Nomad Coordination & Service Discovery sub-category including OSS CoreDNS, etcd and/or Hashicorp Consul Service Management sub-category including OSS envoy, linkerd, gRPC and/or Ambassador and open standard OPA
+•	**Orchestration & Management category:** **cheduling & Orchestration sub-category** including OSS Kubernetes and Hashicorp Nomad **Coordination & Service Discovery sub-category** including OSS CoreDNS, etcd and/or Hashicorp Consul **Service Management sub-category** including OSS envoy, linkerd, gRPC and/or Ambassador and open standard OPA
 
-•	Platforms category: PaaS/Container Service sub-category including OSS Jhipster (for java objects) and/or OSS Kontena Certified Kubernetes - Distribution sub-category including OSS Rancher and/or OSS Canonical Distribution of Kubernetes Certified Kubernetes - Hosted sub-category including public cloud services AWS EKS, Azure ACS and/or Google Kubernetes Engine
+•	**Platforms category:** **PaaS/Container Service sub-category** including OSS Jhipster (for java objects) and/or OSS Kontena **ertified Kubernetes - Distribution sub-category** including OSS Rancher and/or OSS Canonical Distribution of Kubernetes **Certified Kubernetes - Hosted sub-category** including public cloud services AWS EKS, Azure ACS and/or Google Kubernetes Engine
 
-•	Observability and Analysis category: Monitoring sub-category including OSS Prometheus, Grafana, InfluxDB, heapster Logging sub-category including OSS fluentd, Elastic Tracing sub-category including OSS OpenTracing, Jaeger, Zipkin
+•	**Observability and Analysis category:** **Monitoring sub-category** including OSS Prometheus, Grafana, InfluxDB, heapster **ogging sub-category** including OSS fluentd, Elastic **racing sub-category** including OSS OpenTracing, Jaeger, Zipkin
 
      
 ![CNCF Cloud Native Landscape Diagram](https://github.com/cncf/landscape/raw/master/landscape/CloudNativeLandscape_latest.png "CNCF Cloud Native Landscape Diagram")
-For more details on the CNCF Cloud Native Landscape, go here - https://landscape.cncf.io/
+For more details on the CNCF Cloud Native Landscape, go here - **https://landscape.cncf.io/**
 
 ## Logging and monitoring
 All containers from Abixen Platform send logs to [Elasticsearch](https://www.elastic.co) via [Logstash](https://www.elastic.co/products/logstash). You can use [Kibana's](https://www.elastic.co/products/kibana) interface as well.

--- a/README.md
+++ b/README.md
@@ -76,21 +76,31 @@ Abixen Platform is fully compatible with AWS cloud and utilizes the following se
    ![Abixen Platform AWS Deployment diagram](documentation-image/abixen-platform-on-aws.png "Abixen Platform AWS Deployment diagram")
    
 ## CNCF Cloud Native Landscape compatible
-Abixen Platform can be containiized is fully compatible with the CNCF Cloud Native Landscape and utilizes the following components/sub-components and CNCF projects:
+Abixen Platform can be containerized to become fully compatible with CNCF Cloud Native Landscape and it's catogories and sub-catogories of cloud native components. The platform can execute based on the following OSS components and CNCF projects (both OSS and open standards): (this list is initially focused only on the **Infrastructure, Runtime, Orchestration & Management, Platforms and Observability and Analysis categories** of the CNCF Cloud Native Landscape)
 
-- Cloud  – Public or Private, Hybrid or Bare Metal
+- **Infrastructure catogory:**
+	Cloud - Public or Private, Hybrid or Bare Metal (i.e Canonical MaaS or OpenSatck on Bare Metal or any public cloud provider)
 
+- **Runtime catorgory:**
+	**Cloud Native Network sub-catogory** based on the open standard CNI
+	**Container Runtime sub-catogory** including OSS Containerd (docker), rkt and open standard CRI-O
+	**Cloud Native storage sub-catogory** including OSS Rook and/or traditional Swift-based storage options and open standard CSI
 
-   * **Kubernetes** - open-source system for automating deployment, scaling, and management of containerized applications
-   * **ALB** - modern version of load balancer aligned with microservices architecture topology
-   * **ECS** - container orchestrator and scheduler for all services running as docker containers
-   * **ECR** - private container registry for docker images
-   * **Route53** - allows to use internal dns names for communication between microservices
-   * **CloudWatch** - used as a central monitoring and logging
-   * **Elasticache** - used internally by Abixen Platform components
-   * **RDS** - database store for all components
-   * **SES** - used for email communication
-   
+- **Orchestration & Management catorgory:**
+	**Scheduling & Orchestration sub-catogory** including OSS Kubernetes and Hashicorp Nomad
+	**Cooridantion & Service Discovery sub-catogory** including OSS CoreDNS, etcd and/or Hashicorp Consul
+	**Service Management sub-catogory** including OSS envoy, linkerd, gRPC and/or and/or Ambassador and open standard OPA 
+
+- **Platforms catorgory:**
+	**PaaS/Container Service sub-catogory** including OSS Jhipster (for java objects) and/or OSS Kontena
+	**Certified Kubernetes - Distribyution sub-catogory** including OSS Rancher and/or OSS Canonical Distribution of Kubernetes
+	**Certified Kubernetes - Hosted sub-catogory** inclduing public cloud services AWS EKS, Azure ACS and/or Google Kubernetes Engine
+	
+- **Observability and Analysis catorgory:**
+	**Monitoring sub-catogory** inclduing OSS Prometheus, Grafana, InfluxDB, heapster
+	**Logging sub-catogory** inclduing OSS fluentd, Elastic
+	**Tracing sub-catogory** inclduing OSS OpenTracing, Jaeger, Zipkin
+     
 ![CNCF Cloud Native Landscape Diagram](https://github.com/cncf/landscape/raw/master/landscape/CloudNativeLandscape_latest.png "CNCF Cloud Native Landscape Diagram")
 For more details on the CNCF Cloud Native Landscape, go here - https://landscape.cncf.io/
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Abixen Platform can be containerized to become fully compatible with CNCF Cloud 
 
      
 ![CNCF Cloud Native Landscape Diagram](https://github.com/cncf/landscape/raw/master/landscape/CloudNativeLandscape_latest.png "CNCF Cloud Native Landscape Diagram")
-For more details on the CNCF Cloud Native Landscape, go here - **https://landscape.cncf.io/**
+For more details on the CNCF Cloud Native Landscape, go here - https://landscape.cncf.io/
 
 ## Logging and monitoring
 All containers from Abixen Platform send logs to [Elasticsearch](https://www.elastic.co) via [Logstash](https://www.elastic.co/products/logstash). You can use [Kibana's](https://www.elastic.co/products/kibana) interface as well.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Abixen Platform is fully compatible with AWS cloud and utilizes the following se
 ## CNCF Cloud Native Landscape compatible
 Abixen Platform can be containiized is fully compatible with the CNCF Cloud Native Landscape and utilizes the following components/sub-components and CNCF projects:
 
-- Cloud  – Public or Private - Bare Metal
+- Cloud  – Public or Private, Hybrid or Bare Metal
 
 
    * **Kubernetes** - open-source system for automating deployment, scaling, and management of containerized applications
@@ -91,7 +91,8 @@ Abixen Platform can be containiized is fully compatible with the CNCF Cloud Nati
    * **RDS** - database store for all components
    * **SES** - used for email communication
    
-
+https://github.com/cncf/landscape/raw/master/landscape/CloudNativeLandscape_latest.png
+For mre details on the 
 ## Logging and monitoring
 All containers from Abixen Platform send logs to [Elasticsearch](https://www.elastic.co) via [Logstash](https://www.elastic.co/products/logstash). You can use [Kibana's](https://www.elastic.co/products/kibana) interface as well.
 All metrics are exposed on each component with [Jolokia](http://jolokia.org) and fetched from there using [Telegraf](https://influxdata.com/telegraf-correlate-log-metrics-data-performance-bottlenecks/). They are sent to [InfluxDB](https://influxdata.com/) and are accessible on [Grafana](https://grafana.net) dashboards

--- a/README.md
+++ b/README.md
@@ -73,7 +73,24 @@ Abixen Platform is fully compatible with AWS cloud and utilizes the following se
    * **RDS** - database store for all components
    * **SES** - used for email communication
    
-![Abixen Platform AWS Deployment diagram](documentation-image/abixen-platform-on-aws.png "Abixen Platform AWS Deployment diagram")
+   ![Abixen Platform AWS Deployment diagram](documentation-image/abixen-platform-on-aws.png "Abixen Platform AWS Deployment diagram")
+   
+## CNCF Cloud Native Landscape compatible
+Abixen Platform can be containiized is fully compatible with the CNCF Cloud Native Landscape and utilizes the following components/sub-components and CNCF projects:
+
+- Cloud  – Public or Private - Bare Metal
+
+
+   * **Kubernetes** - open-source system for automating deployment, scaling, and management of containerized applications
+   * **ALB** - modern version of load balancer aligned with microservices architecture topology
+   * **ECS** - container orchestrator and scheduler for all services running as docker containers
+   * **ECR** - private container registry for docker images
+   * **Route53** - allows to use internal dns names for communication between microservices
+   * **CloudWatch** - used as a central monitoring and logging
+   * **Elasticache** - used internally by Abixen Platform components
+   * **RDS** - database store for all components
+   * **SES** - used for email communication
+   
 
 ## Logging and monitoring
 All containers from Abixen Platform send logs to [Elasticsearch](https://www.elastic.co) via [Logstash](https://www.elastic.co/products/logstash). You can use [Kibana's](https://www.elastic.co/products/kibana) interface as well.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Abixen Platform is fully compatible with AWS cloud and utilizes the following se
    ![Abixen Platform AWS Deployment diagram](documentation-image/abixen-platform-on-aws.png "Abixen Platform AWS Deployment diagram")
    
 ## CNCF Cloud Native Landscape compatible
-Abixen Platform can be containerized to become fully compatible with CNCF Cloud Native Landscape and its categories and sub-categories of cloud native components. The platform can execute based on the following OSS components and CNCF projects (both OSS and open standards): (this list is initially focused only on the Infrastructure, Runtime, Orchestration & Management, Platforms and Observability and Analysis categories of the CNCF Cloud Native Landscape)
+The Abixen Platform can also be containerized to become fully compatible with CNCF Cloud Native Landscape and its categories and sub-categories of cloud native components. The platform can execute based on the following OSS components and CNCF projects (both OSS and open standards): (**this list of components is initially focused only on the Infrastructure, Runtime, Orchestration & Management, Platforms and Observability and Analysis categories of the CNCF Cloud Native Landscape)**
 
 •	**Infrastructure category:** Cloud - Public or Private, Hybrid or Bare Metal (i.e. Canonical MaaS or OpenStack on Bare Metal or any public cloud provider)
 


### PR DESCRIPTION
Addition of option to deploy abixen platform to a CNCF Cloud Native Landscape compliant platform.  Initial focus of updates is only on the nfrastructure, Runtime, Orchestration & Management, Platforms and Observability and Analysis categories of the CNCF Cloud Native Landscape.